### PR TITLE
added header row functionality to layouts

### DIFF
--- a/acf-json/group_612ff8ca6d684.json
+++ b/acf-json/group_612ff8ca6d684.json
@@ -171,6 +171,33 @@
             ]
         },
         {
+            "key": "field_619592b5172e9",
+            "label": "Header Row",
+            "name": "header_row",
+            "type": "true_false",
+            "instructions": "Whether or not a header row is included in the layout to allow for a full-width grid item to act as a header for the entire layout.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_613a8cde9bc94",
+                        "operator": "==",
+                        "value": "standard"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "Enabled",
+            "ui_off_text": "Disabled"
+        },
+        {
             "key": "field_616923223394a",
             "label": "Masonry Columns",
             "name": "masonry_columns",
@@ -401,6 +428,7 @@
     "hide_on_screen": "",
     "active": false,
     "description": "Settings and styles for the grid layout used in [Layout] Flexible Grid. Adds the ability to manage design aspects for the Flexible Grid layout directly inside the WordPress backend.",
+    "show_in_rest": 0,
     "acfe_display_title": "",
     "acfe_autosync": [
         "json"
@@ -408,7 +436,7 @@
     "acfe_form": 0,
     "acfe_meta": "",
     "acfe_note": "",
-    "modified": 1636141455,
+    "modified": 1637192473,
     "acfe_categories": {
         "settings": "Settings"
     }

--- a/css/base.css
+++ b/css/base.css
@@ -863,6 +863,7 @@ input[type="submit"],
 .columns-3-2 { grid-template-columns: 3fr 2fr; }
 .columns-4-1 { grid-template-columns: 4fr 1fr; }
 
+.grid-display.header-row .layout-item:nth-child(1) { grid-column: 1/-1; }
 
 @media (min-width: 768px) and (max-width: 1024px) {
   .tablet-columns-1 { grid-template-columns: 1fr;}

--- a/inc/generate-settings.php
+++ b/inc/generate-settings.php
@@ -52,6 +52,7 @@ function generateLayout($settings) {
     }
 
     $wrapperClasses .= 'layout grid-display ' . $layoutStructure . ' ';
+    if (get_sub_field('header_row')) {$wrapperClasses .= 'header-row '; }
   } elseif ($gridType == 'masonry') {
     if (have_rows('masonry_columns')) { 
         while (have_rows('masonry_columns')) { the_row();


### PR DESCRIPTION
header rows allow individual layout items to act as an entire row of content. it's useful in scenarios where a layout is being generated, but that layout has some sort of heading above it. instead of that heading acting as a normal layout item, it gets expanded to full-width and the rest of the items follow the normal order/positioning of rows/columns, almost acting as if that heading isn't a part of their layout but is instead a separate layout.